### PR TITLE
Use new API provider and warn about season artwork

### DIFF
--- a/formula1/Fetchnator.py
+++ b/formula1/Fetchnator.py
@@ -173,7 +173,26 @@ class Season:
     def get_round(self, index) -> RoundInfo:
         return self.rounds[index]
 
+    def to_xml_without_artwork(self, filename: str):
+        season_xml = self._build_season_xml()
+
+        # Remove the art element, since it contains a path to a non-exising location in fs
+        art_element = season_xml.getroot().find("./art")
+        season_xml.getroot().remove(art_element)
+
+        season_xml.write(filename, encoding="utf-8", xml_declaration=True)
+
     def to_xml(self, filename: str, mapped_dir, artwork_img_ext):
+        season_xml = self._build_season_xml()
+        season_xml.getroot().findall("./art/poster")[0].text = f"{mapped_dir}/folder{artwork_img_ext}"
+
+        season_xml.write(filename, encoding="utf-8", xml_declaration=True)
+
+    def _build_season_xml(self) -> ET.ElementTree:
+        """
+        Generates the XML elements needed for the season, without the art poster.
+        :return: ElementTree
+        """
         season_xml = ET.parse(f"{os.path.dirname(module_path)}/nfo-template/season.nfo")
         season_xml.getroot().findall("./plot")[0].text = self.season_info
         season_xml.getroot().findall("./dateadded")[0].text = date.today().isoformat()
@@ -182,9 +201,8 @@ class Season:
         season_xml.getroot().findall("./premiered")[0].text = self.start_date
         season_xml.getroot().findall("./enddate")[0].text = self.end_date
         season_xml.getroot().findall("./seasonnumber")[0].text = self.season
-        season_xml.getroot().findall("./art/poster")[0].text = f"{mapped_dir}/folder{artwork_img_ext}"
 
-        season_xml.write(filename, encoding="utf-8", xml_declaration=True)
+        return season_xml
 
     def get_season_poster(self):
         pass

--- a/formula1/Fetchnator.py
+++ b/formula1/Fetchnator.py
@@ -209,7 +209,7 @@ class Season:
 
 
 class Fetchnator:
-    def __init__(self, api="http://ergast.com/api/f1"):
+    def __init__(self, api="https://api.jolpi.ca/ergast/f1"):
         self.api_base = api
         # Test API connection
         requests.get(f"{self.api_base}/2011.json").raise_for_status()

--- a/formula1/Generator.py
+++ b/formula1/Generator.py
@@ -92,6 +92,11 @@ class Generator:
                                     artwork_file_name = season_obj.get_season_poster()
                                 else:
                                     artwork_file_name = artwork_file_name[0]
+
+                                if not artwork_file_name:
+                                    generator_logger.error("Currently artwork is not fetched, it is required to be manually added to each folder/directory with name 'folder.jpg'")
+                                    exit(1)
+
                                 generator_logger.debug("Saving season to xml")
                                 season_obj.to_xml(f"{season_dir_path}/season{self.config['metadata_extension']}",
                                                   f"{self.mapped_dir}/{season_dir}",

--- a/formula1/Generator.py
+++ b/formula1/Generator.py
@@ -93,12 +93,20 @@ class Generator:
                                 else:
                                     artwork_file_name = artwork_file_name[0]
 
+                                # Check if the artwork is found
                                 if not artwork_file_name:
-                                    generator_logger.error("Currently artwork is not fetched, it is required to be manually added to each folder/directory with name 'folder.jpg'")
-                                    exit(1)
+                                    generator_logger.warning(
+                                        f"Season={season_number} artwork was not fetched, it is required to be manually added to your season folder={season_dir_path} as 'folder.jpg'"
+                                    )
 
-                                generator_logger.debug("Saving season to xml")
-                                season_obj.to_xml(f"{season_dir_path}/season{self.config['metadata_extension']}",
+                                    # Save to XML without the artwork
+                                    generator_logger.debug("Saving season to xml")
+                                    season_obj.to_xml_without_artwork(f"{season_dir_path}/season{self.config['metadata_extension']}")
+
+                                else:
+                                    generator_logger.debug("Saving season to xml")
+                                    # Save to XML with the artwork
+                                    season_obj.to_xml(f"{season_dir_path}/season{self.config['metadata_extension']}",
                                                   f"{self.mapped_dir}/{season_dir}",
                                                   os.path.splitext(artwork_file_name)[1])
 


### PR DESCRIPTION
- See https://github.com/jolpica/jolpica-f1/tree/main for new API which is backwards-compatible
- I had some trouble reading the Python code, so simply inform the user when artwork is missing from the season directory